### PR TITLE
build: migrate to new CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build
 .idea/
 .vscode/
 bin/
+
+# Ignore Alchemist folder specified for export
+data

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,38 +70,27 @@ File(rootProject.rootDir.path + "/src/main/yaml").listFiles()
                 },
             )
             // These are the program arguments
-            args("run", it.absolutePath)
+            args("run", it.absolutePath, "--override")
             if (System.getenv("CI") == "true" || batch == "true") {
                 // If it is running in a Continuous Integration environment, use the "headless" mode of the simulator
                 // Namely, force the simulator not to use graphical output.
                 args(
-                    "--override'",
                     """
-                    {
-                      "terminate": [
-                        {
-                          "type": "AfterTime",
-                          "parameters": $maxTime
-                        }
-                      ]
-                    }
+                        terminate:
+                        - type: AfterTime
+                          parameters: $maxTime
                     """.trimIndent(),
                 )
             } else {
                 // A graphics environment should be available, so load the effects for the UI from the "effects" folder
                 // Effects are expected to be named after the simulation file
                 args(
-                    "--override",
                     """
-                    {
-                      "launcher": {
-                        "type": "SingleRunSwingUI",
-                        "parameters": {
-                          "graphics": "effects/${it.nameWithoutExtension}.json"
-                        }
-                      }
-                    }
-                """,
+                        launcher:
+                          type: SingleRunSwingUI
+                          parameters:
+                            graphics: effects/${it.nameWithoutExtension}.json
+                    """,
                 )
             }
             // This tells gradle that this task may modify the content of the export directory

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,15 +54,6 @@ File(rootProject.rootDir.path + "/src/main/yaml").listFiles()
             description = "Launches simulation ${it.nameWithoutExtension}" // Just documentation
             mainClass.set("it.unibo.alchemist.Alchemist") // The class to launch
             classpath = sourceSets["main"].runtimeClasspath // The classpath to use
-            // In case our simulation produces data, we write it in the following folder:
-            val exportsDir = File("${projectDir.path}/build/exports/${it.nameWithoutExtension}")
-            doFirst {
-                // this is not executed upfront, but only when the task is actually launched
-                // If the export folder does not exist, create it and its parents if needed
-                if (!exportsDir.exists()) {
-                    exportsDir.mkdirs()
-                }
-            }
             // Uses the latest version of java
             javaLauncher.set(
                 javaToolchains.launcherFor {
@@ -93,8 +84,6 @@ File(rootProject.rootDir.path + "/src/main/yaml").listFiles()
                     """,
                 )
             }
-            // This tells gradle that this task may modify the content of the export directory
-            outputs.dir(exportsDir)
         }
         // task.dependsOn(classpathJar) // Uncomment to switch to jar-based classpath resolution
         runAll.dependsOn(task)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-alchemist = "26.0.13"
+alchemist = "28.0.1"
 
 [libraries]
 alchemist = { module = "it.unibo.alchemist:alchemist", version.ref = "alchemist" }


### PR DESCRIPTION
@DanySK please read this before accepting. Was the `-e` option already deprecated or something in 26.0.13? I could not find any usage in the actual Alchemist code. For now i removed it, but the export directory is still declared.

I could do one of these things:
- add an exporter as stated [here](http://alchemistsimulator.github.io/howtos/simulation/export/index.html) (is it the same thing?).
- delete the export directory from the build configuration.
